### PR TITLE
feat(client): add client logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,6 @@ dependencies = [
  "tower",
  "tower-http 0.5.1",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
  "tui-realm-stdlib",
  "tuirealm",
@@ -406,21 +405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,15 +453,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -1126,12 +1101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,12 +1277,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1895,37 +1858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,18 +2112,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
-dependencies = [
- "crossbeam-channel",
- "thiserror",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "tower",
  "tower-http 0.5.1",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tui-realm-stdlib",
  "tuirealm",
@@ -405,6 +406,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +469,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1101,6 +1126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1308,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1858,6 +1895,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2180,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ tracing-subscriber = "0.3.18"
 tower-http = { version = "0.5.1", features = ["trace"] }
 random_name_generator = "0.3.4"
 tower = "0.4.13"
-tracing-appender = "0.2.3"
 
 [features]
 client_logs = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 crossterm = "0.27.0"
 ratatui = "0.24.0"
-tokio = { version = "1.35.1", features = ["macros"] }
+tokio = { version = "1.35.1", features = ["macros", "fs"] }
 tui-realm-stdlib = "1.3.0"
 tonic = "0.7"
 prost = "0.10"
@@ -30,6 +30,10 @@ tracing-subscriber = "0.3.18"
 tower-http = { version = "0.5.1", features = ["trace"] }
 random_name_generator = "0.3.4"
 tower = "0.4.13"
+tracing-appender = "0.2.3"
+
+[features]
+client_logs = []
 
 [build-dependencies]
 tonic-build = "0.7"

--- a/src/app/network.rs
+++ b/src/app/network.rs
@@ -13,7 +13,7 @@ use super::{
     utils,
 };
 
-#[derive(PartialEq, Eq, Clone, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Clone, PartialOrd)]
 pub enum UserEvent {
     InfoMessage(String),
     NetworkError(String),
@@ -27,7 +27,7 @@ pub enum UserEvent {
     GameStart,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
 pub struct UserDetails {
     pub user_id: String,
     pub user_name: String,
@@ -63,6 +63,7 @@ impl<U> DisplayNetworkError for Result<tonic::Response<U>, tonic::Status> {
         match self {
             Ok(res) => Some(res.into_inner()),
             Err(tonic_status) => {
+                tracing::error!(network_error=?tonic_status);
                 let stringified_error = tonic_status.message();
                 network_client
                     .messsages
@@ -169,25 +170,24 @@ async fn handle_room_service_stream(
 }
 
 #[cfg(feature = "client_logs")]
-fn setup_tracing() -> WorkerGuard {
+fn setup_tracing() {
     use tracing::level_filters::LevelFilter;
+    use tracing_subscriber::layer::{Layer, SubscriberExt};
 
-    let appender = tracing_appender::rolling::RollingFileAppender::new(
-        tracing_appender::rolling::Rotation::NEVER,
-        "",
-        "client_logs.json",
-    );
+    // This is a sync / blocking writer, an async / non-blockng writer will be an overkill for this purpose
+    let log_writer = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open("client_logs")
+        .unwrap();
 
-    let (non_blocking, _guard) = tracing_appender::non_blocking(appender);
     let file_layer = tracing_subscriber::fmt::Layer::new()
-        .with_writer(non_blocking)
+        .with_writer(log_writer)
         .with_filter(LevelFilter::INFO);
 
     let subscriber = tracing_subscriber::Registry::default().with(file_layer);
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
-
-    _guard
 }
 
 impl NetworkClient {
@@ -198,9 +198,9 @@ impl NetworkClient {
         config: ClientConfig,
     ) {
         #[cfg(feature = "client_logs")]
-        let _tracing_guard = setup_tracing();
+        setup_tracing();
 
-        tracing::info!("network thread started");
+        tracing::info!("Network thread Started");
 
         let mut client = match grpc_client::GrpcClient::connect(config.server_url.clone()).await {
             Ok(grpc_client) => {
@@ -208,16 +208,23 @@ impl NetworkClient {
                     "Successfully connected to server at address {}",
                     config.server_url
                 );
+
+                tracing::info!(
+                    "Connection to server at address {} successful",
+                    config.server_url
+                );
+
                 self.push_user_event(UserEvent::InfoMessage(message));
                 grpc_client
             }
 
             Err(network_error) => {
-                let error = format!("Connection to server failed {network_error:?}");
-                self.messsages
-                    .lock()
-                    .unwrap()
-                    .push(UserEvent::NetworkError(error));
+                let error = format!(
+                    "Connection to server at address {} failed {network_error:?}",
+                    config.server_url
+                );
+
+                tracing::error!(error);
 
                 // Add the retry logic for exponential retry
                 return;
@@ -232,7 +239,9 @@ impl NetworkClient {
             user_id: local_storage.and_then(|user_details| user_details.client_id),
         };
 
+        tracing::info!(?ping_request);
         let ping_result = client.ping(ping_request).await;
+        tracing::info!(?ping_result);
 
         if let Some(ping_response) = ping_result.error_handler(self) {
             let client_id = ping_response.user_id;
@@ -297,7 +306,7 @@ impl NetworkClient {
     }
 
     fn push_user_event(&self, event: UserEvent) {
-        self.messsages.lock().unwrap().push(event)
+        tracing::info!(push_user_event=?event);
     }
 }
 

--- a/src/app/network.rs
+++ b/src/app/network.rs
@@ -4,8 +4,6 @@ use crate::grpc::server::{grpc_client, PingRequest, RoomServiceRequest, RoomServ
 
 use tokio_stream::StreamExt;
 
-use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{layer::SubscriberExt, Layer};
 use tuirealm::listener::Poll;
 
 use super::{
@@ -182,6 +180,9 @@ fn setup_tracing() {
         .unwrap();
 
     let file_layer = tracing_subscriber::fmt::Layer::new()
+        .with_ansi(false)
+        .with_level(true)
+        .with_line_number(true)
         .with_writer(log_writer)
         .with_filter(LevelFilter::INFO);
 


### PR DESCRIPTION
This PR adds the capability to add logs to client, this helps in debugging. A feature called `client_logs` is added to the binary ( currently both client and server share the same cargo.toml, this has to be refactored later ). The logs are available only when the client is run with the feature `client_logs`

```bash
cargo r --bin client  --features client_logs
```

in another terminal execute the command
```bash
tail -f client_logs
```

## Note
This feature is to be used for debugging purposes only. The sync writer ( std::fs::write ) is not that efficient when it comes to io as it performs blocking write. 
