### PR TITLE
refactor(server): eliminate the need to have a secondary channel

### DIFF
--- a/src/app/client/network.rs
+++ b/src/app/client/network.rs
@@ -61,9 +61,7 @@ fn handle_room_service_message(message: RoomServiceResponse, network_client: Net
 
     match message_type {
         RoomServiceResponseType::Init => {
-            let room_id = message
-                .room_id
-                .expect("Required room id, but did not find in init message");
+            let room_id = message.room_id;
 
             let users = message
                 .user_details
@@ -87,9 +85,7 @@ fn handle_room_service_message(message: RoomServiceResponse, network_client: Net
             network_client.push_user_event(user_joined_event);
         }
         RoomServiceResponseType::GameStart => {
-            let room_id = message
-                .room_id
-                .expect("Required room id, but did not find in game start message");
+            let room_id = message.room_id;
 
             let users = message
                 .user_details

--- a/src/app/server/grpc/grpc.proto
+++ b/src/app/server/grpc/grpc.proto
@@ -61,7 +61,7 @@ message RoomServiceResponse {
     MESSAGE_TYPE_USER_JOINED = 2;
     MESSAGE_TYPE_GAME_START = 3;
   }
-  optional string room_id = 1;
+  string room_id = 1;
   MessageType message_type = 2;
   repeated UserDetails user_details = 3;
 }

--- a/src/app/server/grpc/server.rs
+++ b/src/app/server/grpc/server.rs
@@ -48,7 +48,7 @@ impl MyGrpc {
         // Create the common room if not exists at the application startup
         let store = Store {
             redis_client,
-            session_state: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            room_users_state: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let common_room = store.find_room(types::COMMON_ROOM_KEY).await;

--- a/src/app/server/grpc/storage.rs
+++ b/src/app/server/grpc/storage.rs
@@ -5,21 +5,24 @@ use std::{
 
 use crate::app::server::{
     errors::DbError,
-    grpc::{redis_client::RedisClient, storage::interface::StorageInterface},
+    grpc::{
+        redis_client::RedisClient, server::RoomServiceResponse,
+        storage::interface::StorageInterface,
+    },
 };
 
 pub mod interface;
 pub mod models;
 
 /// Store the client connections to this instance of the application
-type SessionState =
-    Arc<Mutex<HashMap<String, tokio::sync::mpsc::Sender<super::types::RoomMessage>>>>;
+type SessionState<T> = Arc<Mutex<HashMap<String, T>>>;
 
 /// A store that holds the storage clients for various storage types
 #[derive(Clone)]
 pub struct Store {
     pub redis_client: RedisClient,
-    pub session_state: SessionState,
+    pub room_users_state:
+        SessionState<tokio::sync::mpsc::Sender<Result<RoomServiceResponse, tonic::Status>>>,
 }
 
 impl StorageInterface for Store {}

--- a/src/app/server/grpc/storage/interface/session.rs
+++ b/src/app/server/grpc/storage/interface/session.rs
@@ -1,35 +1,59 @@
 use crate::app::server::grpc::{
+    server::RoomServiceResponse,
     storage::{StorageResult, Store},
     types::RoomMessage,
 };
 
-type SessionChannel = tokio::sync::mpsc::Sender<RoomMessage>;
+type SessionChannel = tokio::sync::mpsc::Sender<Result<RoomServiceResponse, tonic::Status>>;
 
 /// To store the user channels who are connected
+/// This has to be generic over the message
+///
+/// Channels can be inserted and removed for the same user based on the current interaction
 pub trait SessionInterface {
     fn insert_channel(&self, user_id: &str, channel: SessionChannel) -> StorageResult<()>;
     fn get_channel(&self, user_id: &str) -> StorageResult<SessionChannel>;
     fn remove_channel(&self, user_id: &str) -> StorageResult<()>;
+    fn send_message_to_user(
+        &self,
+        user_id: &str,
+        message: RoomMessage,
+    ) -> impl std::future::Future<Output = StorageResult<()>>;
 }
 
 impl SessionInterface for Store {
     fn insert_channel(&self, user_id: &str, channel: SessionChannel) -> StorageResult<()> {
-        let mut connected_users = self.session_state.lock().unwrap();
+        let mut connected_users = self.room_users_state.lock().unwrap();
         connected_users.insert(user_id.to_string(), channel);
         Ok(())
     }
 
     #[track_caller]
     fn get_channel(&self, user_id: &str) -> StorageResult<SessionChannel> {
-        let connected_users = self.session_state.lock().unwrap();
+        let connected_users = self.room_users_state.lock().unwrap();
         let user_channel = connected_users.get(user_id).unwrap().clone();
         Ok(user_channel)
     }
 
     fn remove_channel(&self, user_id: &str) -> StorageResult<()> {
-        let mut connected_users = self.session_state.lock().unwrap();
+        let mut connected_users = self.room_users_state.lock().unwrap();
         let user_channel = connected_users.remove(user_id).unwrap().clone();
         drop(user_channel);
         Ok(())
+    }
+
+    fn send_message_to_user(
+        &self,
+        user_id: &str,
+        message: RoomMessage,
+    ) -> impl std::future::Future<Output = StorageResult<()>> {
+        let grpc_response = RoomServiceResponse::from(message);
+        async {
+            let user_channel = self.get_channel(user_id)?;
+
+            user_channel.send(Ok(grpc_response)).await.unwrap();
+
+            Ok(())
+        }
     }
 }

--- a/src/app/server/grpc/types.rs
+++ b/src/app/server/grpc/types.rs
@@ -1,3 +1,5 @@
+use crate::app::{server::grpc::server::RoomServiceResponse, types::RoomServiceResponseType};
+
 use super::storage::models;
 
 pub const COMMON_ROOM_KEY: &str = "COMMON_ROOM";
@@ -21,4 +23,31 @@ pub enum RoomMessage {
         room_id: String,
         users: Vec<models::User>,
     },
+}
+
+impl From<RoomMessage> for RoomServiceResponse {
+    fn from(value: RoomMessage) -> Self {
+        match value {
+            RoomMessage::AllUsersJoined { room_id, users } => RoomServiceResponse {
+                room_id,
+                message_type: RoomServiceResponseType::GameStart.to_u8().into(),
+                user_details: users.into_iter().map(From::from).collect::<Vec<_>>(),
+            },
+            RoomMessage::RoomCreated { room_id, users } => RoomServiceResponse {
+                room_id,
+                message_type: RoomServiceResponseType::Init.to_u8().into(),
+                user_details: users.into_iter().map(From::from).collect::<Vec<_>>(),
+            },
+            RoomMessage::RoomJoined { room_id, users } => RoomServiceResponse {
+                room_id,
+                message_type: RoomServiceResponseType::Init.to_u8().into(),
+                user_details: users.into_iter().map(From::from).collect::<Vec<_>>(),
+            },
+            RoomMessage::UserJoined { room_id, users } => RoomServiceResponse {
+                room_id,
+                message_type: RoomServiceResponseType::UserJoined.to_u8().into(),
+                user_details: users.into_iter().map(From::from).collect::<Vec<_>>(),
+            },
+        }
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,1 +1,3 @@
 pub use blazer::*;
+
+pub fn create_client() {}


### PR DESCRIPTION
Currently in order to communicate to the connected clients, we need to store the sender channel. The sender channel can be cloned, since it is an mpsc channel. This can be safely stored inside a mutex, and whenever required a lock can be acquired, the sender can be cloned and then a message can be sent to the sender channel in async way.

Sending to an async channel when a mutex guard is held is not advisable because there might be some starvation, the mutex guard will be held untill the message will be sent and then it will be dropped. In this case, if any other thread wants to lock the mutex, it will not have access to it 