### PR TITLE
feat: add graceful shutdown to tonic server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,12 +255,15 @@ dependencies = [
  "error-stack",
  "fred",
  "log",
+ "oneshot",
  "prost",
  "rand",
  "random_name_generator",
  "ratatui 0.24.0",
  "serde",
  "serde_json",
+ "signal-hook",
+ "signal-hook-tokio",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1162,6 +1165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oneshot"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1743,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ random_name_generator = "0.3.4"
 tower = "*"
 tonic-reflection = "0.11"
 clap = { version = "4.5.6", features = ["derive"] }
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
+signal-hook = "0.3.17"
+oneshot = "0.1.8"
 
 [features]
 client_logs = []

--- a/config/server.toml
+++ b/config/server.toml
@@ -1,1 +1,2 @@
 port = 6969
+test_mode = false

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -5,17 +5,44 @@ use app::server::grpc::{
     server::{grpc_server, MyGrpc, FILE_DESCRIPTOR_SET},
     utils::create_redis_client,
 };
+use tokio_stream::StreamExt;
+
+fn get_signals() -> signal_hook_tokio::Signals {
+    signal_hook_tokio::Signals::new(&[signal_hook::consts::SIGINT])
+        .expect("Unable to register the signals for graceful shutdown")
+}
+
+async fn handle_signal(
+    mut signals: signal_hook_tokio::Signals,
+    shutdown_informer: tokio::sync::oneshot::Sender<()>,
+) {
+    while let Some(signal) = signals.next().await {
+        match signal {
+            signal_hook::consts::SIGINT => {
+                tracing::warn!("Received signal to shutdown");
+                shutdown_informer
+                    .send(())
+                    .expect("Unable to inform shutdown signal");
+                break;
+            }
+            _ => unreachable!(),
+        }
+    }
+}
 
 use crate::app::{self, types};
 
 pub async fn start_server(
-    _test_mode: bool,
     server_config: types::ServerConfig,
     tcp_listener: tokio::net::TcpListener,
 ) {
     let redis_client = create_redis_client(server_config.redis.unwrap_or_default())
         .await
         .unwrap();
+
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let shutdown_signals = get_signals();
+    tokio::spawn(handle_signal(shutdown_signals, sender));
 
     let service = MyGrpc::new(redis_client).await;
 
@@ -29,7 +56,15 @@ pub async fn start_server(
     tonic::transport::Server::builder()
         .add_service(reflection_service)
         .add_service(grpc_server::GrpcServer::new(service))
-        .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(tcp_listener))
+        .serve_with_incoming_shutdown(
+            tokio_stream::wrappers::TcpListenerStream::new(tcp_listener),
+            async {
+                receiver.await.unwrap();
+                tracing::info!("Initiating graceful shutdown, waiting for tasks to finish");
+            },
+        )
         .await
         .expect("Could not start the server");
+
+    tracing::info!("Server shutdown");
 }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1,7 +1,8 @@
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Default)]
 pub struct ServerConfig {
     pub server: Option<Server>,
     pub redis: Option<RedisConfig>,
+    pub test_mode: bool,
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -18,6 +18,6 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .expect("Could not bind to server address {server_address}");
 
-    blazer::app::server::start_server(false, config, tcp_listener).await;
+    blazer::app::server::start_server(config, tcp_listener).await;
     Ok(())
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -27,7 +27,7 @@ async fn connect() {
     let config =
         utils::read_config::<types::ServerConfig>("config/server.toml", Some("BLAZER_SERVER"));
     let tcp_listener = configure_server(&config).await;
-    tokio::spawn(async { start_server(true, config, tcp_listener).await });
+    tokio::spawn(async { start_server(config, tcp_listener).await });
 
     let config = utils::read_config::<ClientConfig>("config/client.toml", Some("BLAZER"));
 


### PR DESCRIPTION
This works on the signals that are received
In case we receive a sigint, the server waits to ongoing streams to be closed and then shutdown the server

Further work on this is to make use of graceful shutdowns in case of integration tests to handle the server shutdowns cleanly